### PR TITLE
Fixed `:UgatermOpen` crashing on stable neovim when passing args

### DIFF
--- a/lua/ugaterm/init.lua
+++ b/lua/ugaterm/init.lua
@@ -25,10 +25,10 @@ local function parse(fargs, options)
     local arg = fargs[i]
     local flag = arg:sub(2)
     if vim.startswith(arg, "-") then
-      if vim.list_contains(options.string or {}, flag) then
+      if vim.tbl_contains(options.string or {}, flag) then
         i = i + 1
         parsedArgs.string[flag] = fargs[i]
-      elseif vim.list_contains(options.boolean or {}, flag) then
+      elseif vim.tbl_contains(options.boolean or {}, flag) then
         parsedArgs.boolean[flag] = true
       end
     else


### PR DESCRIPTION
When running `:UgatermOpen -toggle` or passing any other arg, the plugin crashes on stable neovim.

Stable neovim doesn't have `vim.list_contains`, but has `vim.tbl_contains`.
By looking at the source code of `tbl_contains` and `list_contains`, if we use `tbl_contains` without passing additional opts, it acts exactly like `list_contains`.

Tested on NVIM v0.9.5.